### PR TITLE
Add alternative startup method

### DIFF
--- a/oa_hash.h
+++ b/oa_hash.h
@@ -30,11 +30,20 @@ struct oa_hash_entry {
     void *value; /**< value pointer */
 };
 
+#define __OA_HASH_ATTRS_const                                                 \
+    const size_t length; /**< amount of entries */                            \
+    const size_t capacity; /**< total buckets capacity */                     \
+    const struct oa_hash_entry *buckets /**< entries array */
+#define __OA_HASH_ATTRS_mut                                                   \
+    size_t length; /**< amount of entries */                                  \
+    size_t capacity; /**< total buckets capacity */                           \
+    struct oa_hash_entry *buckets /**< entries array */
+/** @brief can be used to cast to struct oa_hash */
+#define OA_HASH_ATTRS(_qualifier) __OA_HASH_ATTRS_##_qualifier
+
 /** @brief Open addressing hash table */
 struct oa_hash {
-    size_t length; /**< amount of entries */
-    size_t capacity; /**< total buckets capacity */
-    struct oa_hash_entry *buckets; /**< entries array */
+    OA_HASH_ATTRS(mut);
 };
 
 /**

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,7 @@ CC = cc
 
 EXES = test
 
-CFLAGS += -Wall -Wextra -Wpedantic -g -I$(TOP) -std=c99
+CFLAGS += -Wall -Wextra -Wpedantic -g -I$(TOP) -std=c89
 
 all: $(EXES)
 

--- a/test/test.c
+++ b/test/test.c
@@ -135,17 +135,17 @@ test_linear_probing_wraparound(void)
     int val1 = 1, val2 = 2;
     const struct oa_hash_entry *entry;
 
-    // Force hash collision by using same hash value
+    /* Force hash collision by using same hash value */
     entry = oa_hash_set_entry(&ht, "cw", 2, &val1);
     ASSERT(entry != NULL);
     ASSERT_EQ(&val1, entry->value);
 
-    // Should wrap around and find next empty slot
+    /* Should wrap around and find next empty slot */
     entry = oa_hash_set_entry(&ht, "wc", 2, &val2);
     ASSERT(entry != NULL);
     ASSERT_EQ(&val2, entry->value);
 
-    // Verify both values are still accessible
+    /* Verify both values are still accessible */
     entry = oa_hash_get_entry(&ht, "cw", 2);
     ASSERT(entry != NULL);
     ASSERT_EQ(&val1, entry->value);
@@ -163,15 +163,15 @@ test_key_length_handling(void)
     int val1 = 1, val2 = 2;
     const struct oa_hash_entry *entry;
 
-    // Insert key with embedded null bytes
+    /* Insert key with embedded null bytes */
     entry = oa_hash_set_entry(&ht, "u\0a", 3, &val1);
     ASSERT(entry != NULL);
 
-    // Different key with same prefix should not match
+    /* Different key with same prefix should not match */
     entry = oa_hash_set_entry(&ht, "u\0b", 3, &val2);
     ASSERT(entry != NULL);
 
-    // Verify correct value is returned
+    /* Verify correct value is returned */
     entry = oa_hash_get_entry(&ht, "u\0a", 3);
     ASSERT(entry != NULL);
     ASSERT_EQ(&val1, entry->value);
@@ -190,13 +190,14 @@ test_lookup_stops_at_empty(void)
     const struct oa_hash_entry *entry;
     size_t i;
 
-    // Fill first few slots
+    /* Fill first few slots */
     for (i = 0; i < 3; i++) {
-        char key[2] = { 'a' + i, '\0' };
+        char key[2] = { 'a', '\0' };
+        key[0] += i;
         ASSERT(oa_hash_set_entry(&ht, key, 1, &val) != NULL);
     }
 
-    // Lookup of non-existent key should stop at first empty slot
+    /* Lookup of non-existent key should stop at first empty slot */
     entry = oa_hash_get_entry(&ht, "test", 4);
     ASSERT(entry == NULL);
 
@@ -209,19 +210,19 @@ test_deletion_with_gravestones(void)
     const struct oa_hash_entry *entry;
     int val1 = 1, val2 = 2;
 
-    // Insert two entries that may collide
+    /* Insert two entries that may collide */
     ASSERT(oa_hash_set_entry(&ht, "test1", 5, &val1) != NULL);
     ASSERT(oa_hash_set_entry(&ht, "test2", 5, &val2) != NULL);
 
-    // Remove first entry
+    /* Remove first entry */
     ASSERT(oa_hash_remove(&ht, "test1", 5));
 
-    // Second entry should still be accessible
+    /* Second entry should still be accessible */
     entry = oa_hash_get_entry(&ht, "test2", 5);
     ASSERT(entry != NULL);
     ASSERT_EQ(&val2, entry->value);
 
-    // Verify first entry slot is marked as deleted
+    /* Verify first entry slot is marked as deleted */
     entry = oa_hash_get_entry(&ht, "test1", 5);
     ASSERT(entry == NULL);
 


### PR DESCRIPTION
So that structs may be cast to struct oa_hash instead of holding a hashtable attribute